### PR TITLE
better naming for functions urlToStaticData, urlToChachedData and urlToTempData

### DIFF
--- a/backends/filesystem_android/filesystem/FileSystem.hx
+++ b/backends/filesystem_android/filesystem/FileSystem.hx
@@ -53,18 +53,33 @@ class FileSystem
 	/// NATIVE ACCESS
 
 	private var staticDataURL : String;
+	public function getUrlToStaticData() : String
+	{
+		return staticDataURL;
+	}
+	@:deprecated("urlToStaticData is deprecated. Use FileSystem.getUrlToStaticData() instead!")
 	public function urlToStaticData() : String
 	{
 		return staticDataURL;
 	}
 
 	private var cachedDataURL : String;
+	public function getUrlToCachedData() : String
+	{
+		return cachedDataURL;
+	}
+	@:deprecated("urlToCachedData is deprecated. Use FileSystem.getUrlToCachedData() instead!")
 	public function urlToCachedData() : String
 	{
 		return cachedDataURL;
 	}
 
 	private var tempDataURL : String;
+	public function getUrlToTempData() : String
+	{
+		return tempDataURL;
+	}
+	@:deprecated("urlToTempData is deprecated. Use FileSystem.getUrlToTempData() instead!")
 	public function urlToTempData() : String
 	{
 		return tempDataURL;

--- a/backends/filesystem_flash/filesystem/FileSystem.hx
+++ b/backends/filesystem_flash/filesystem/FileSystem.hx
@@ -106,7 +106,6 @@ class FileSystem
         return filteredFiles;
     }
 
-    private var staticDataURL : String;
 	public function getUrlToStaticData() : String
 	{
 		return staticDataURL;
@@ -117,7 +116,6 @@ class FileSystem
 		return staticDataURL;
 	}
 
-	private var cachedDataURL : String;
 	public function getUrlToCachedData() : String
 	{
 		return cachedDataURL;
@@ -128,7 +126,6 @@ class FileSystem
 		return cachedDataURL;
 	}
 
-	private var tempDataURL : String;
 	public function getUrlToTempData() : String
 	{
 		return tempDataURL;

--- a/backends/filesystem_flash/filesystem/FileSystem.hx
+++ b/backends/filesystem_flash/filesystem/FileSystem.hx
@@ -106,20 +106,38 @@ class FileSystem
         return filteredFiles;
     }
 
-    public function urlToStaticData(): String
-    {
-        return staticDataURL;
-    }
+    private var staticDataURL : String;
+	public function getUrlToStaticData() : String
+	{
+		return staticDataURL;
+	}
+	@:deprecated("urlToStaticData is deprecated. Use FileSystem.getUrlToStaticData() instead!")
+	public function urlToStaticData() : String
+	{
+		return staticDataURL;
+	}
 
-    public function urlToCachedData(): String
-    {
-        return cachedDataURL;
-    }
+	private var cachedDataURL : String;
+	public function getUrlToCachedData() : String
+	{
+		return cachedDataURL;
+	}
+	@:deprecated("urlToCachedData is deprecated. Use FileSystem.getUrlToCachedData() instead!")
+	public function urlToCachedData() : String
+	{
+		return cachedDataURL;
+	}
 
-    public function urlToTempData(): String
-    {
-        return tempDataURL;
-    }
+	private var tempDataURL : String;
+	public function getUrlToTempData() : String
+	{
+		return tempDataURL;
+	}
+	@:deprecated("urlToTempData is deprecated. Use FileSystem.getUrlToTempData() instead!")
+	public function urlToTempData() : String
+	{
+		return tempDataURL;
+	}
 
     public function createFile(url: String): Bool
     {

--- a/backends/filesystem_html5/filesystem/FileSystem.hx
+++ b/backends/filesystem_html5/filesystem/FileSystem.hx
@@ -76,19 +76,34 @@ class FileSystem
 		return filteredFiles;
 	}
 
-	private var staticDataURL : String = "static://";
+	private var staticDataURL : String;
+	public function getUrlToStaticData() : String
+	{
+		return staticDataURL;
+	}
+	@:deprecated("urlToStaticData is deprecated. Use FileSystem.getUrlToStaticData() instead!")
 	public function urlToStaticData() : String
 	{
 		return staticDataURL;
 	}
 
-	private var cachedDataURL : String = "cached://";
+	private var cachedDataURL : String;
+	public function getUrlToCachedData() : String
+	{
+		return cachedDataURL;
+	}
+	@:deprecated("urlToCachedData is deprecated. Use FileSystem.getUrlToCachedData() instead!")
 	public function urlToCachedData() : String
 	{
 		return cachedDataURL;
 	}
 
-	private var tempDataURL : String = "temp://";
+	private var tempDataURL : String;
+	public function getUrlToTempData() : String
+	{
+		return tempDataURL;
+	}
+	@:deprecated("urlToTempData is deprecated. Use FileSystem.getUrlToTempData() instead!")
 	public function urlToTempData() : String
 	{
 		return tempDataURL;

--- a/backends/filesystem_ios/filesystem/FileSystem.hx
+++ b/backends/filesystem_ios/filesystem/FileSystem.hx
@@ -44,18 +44,33 @@ class FileSystem
 	/// NATIVE ACCESS
 
 	private var staticDataURL : String;
+	public function getUrlToStaticData() : String
+	{
+		return staticDataURL;
+	}
+	@:deprecated("urlToStaticData is deprecated. Use FileSystem.getUrlToStaticData() instead!")
 	public function urlToStaticData() : String
 	{
 		return staticDataURL;
 	}
 
 	private var cachedDataURL : String;
+	public function getUrlToCachedData() : String
+	{
+		return cachedDataURL;
+	}
+	@:deprecated("urlToCachedData is deprecated. Use FileSystem.getUrlToCachedData() instead!")
 	public function urlToCachedData() : String
 	{
 		return cachedDataURL;
 	}
 
 	private var tempDataURL : String;
+	public function getUrlToTempData() : String
+	{
+		return tempDataURL;
+	}
+	@:deprecated("urlToTempData is deprecated. Use FileSystem.getUrlToTempData() instead!")
 	public function urlToTempData() : String
 	{
 		return tempDataURL;

--- a/filesystem/FileSystem.hx
+++ b/filesystem/FileSystem.hx
@@ -32,9 +32,9 @@ extern class FileSystem
 	public static function initialize(finishedCallback : Void->Void ):Void;
 	public static function instance() : FileSystem;
 
-	public function urlToStaticData() : String;
-	public function urlToCachedData() : String;
-	public function urlToTempData() : String;
+	public function getUrlToStaticData() : String;
+	public function getUrlToCachedData() : String;
+	public function getUrlToTempData() : String;
 
 	public function getFileWriter(url : String) : FileWriter;
 	public function getFileReader(url : String) : FileReader;

--- a/filesystem/FileSystem.hx
+++ b/filesystem/FileSystem.hx
@@ -35,6 +35,10 @@ extern class FileSystem
 	public function getUrlToStaticData() : String;
 	public function getUrlToCachedData() : String;
 	public function getUrlToTempData() : String;
+	/// deprecated 
+	public function urlToStaticData() : String;
+	public function urlToCachedData() : String;
+	public function urlToTempData() : String;
 
 	public function getFileWriter(url : String) : FileWriter;
 	public function getFileReader(url : String) : FileReader;


### PR DESCRIPTION
Sometimes I get confused wether the urlToStaticData, urlToChachedData and urlToTempData are properties or functions So I changed there names to remove the confusion.
So now they are called getUrlToStaticData, getUrlToChachedData and getUrlToTempData .
the old names still exist as deprecated functions So there is no breaking changes.
I suggest keeping it this way for sometime and then when we make major version we remove the deprecated functions. 
