### PR TITLE
HTML5 fixed seek position on reads and writes

### DIFF
--- a/backends/filesystem_html5/filesystem/FileReader.hx
+++ b/backends/filesystem_html5/filesystem/FileReader.hx
@@ -57,6 +57,8 @@ class FileReader
 		fileData.offset = currentSeekPosition;
 		fileData.offsetLength = data.offsetLength;
 		data.writeData(fileData);
+		
+		currentSeekPosition = fileData.offset + fileData.offsetLength;
 	}
 
 	public function close()

--- a/backends/filesystem_html5/filesystem/FileWriter.hx
+++ b/backends/filesystem_html5/filesystem/FileWriter.hx
@@ -64,6 +64,8 @@ class FileWriter
 		fileData.offset = currentSeekPosition;
 		fileData.offsetLength = data.offsetLength;
 		fileData.writeData(data);
+
+		currentSeekPosition = fileData.offset + fileData.offsetLength;
 	}
 
 	public function close()


### PR DESCRIPTION
On HTML5 the file reader and writer weren't advancing the seek position on a read/write. That's how it works on every other target, so HTML5 does the same now.
